### PR TITLE
Remove timezone offset

### DIFF
--- a/custom_components/bureau_of_meteorology/weather.py
+++ b/custom_components/bureau_of_meteorology/weather.py
@@ -79,7 +79,7 @@ class WeatherBase(WeatherEntity):
         tzinfo = zoneinfo.ZoneInfo(self.collector.locations_data["data"]["timezone"])
         return [
             Forecast(
-                datetime=iso8601.parse_date(data["date"]).astimezone(tzinfo).isoformat(),
+                datetime=iso8601.parse_date(data["date"]).astimezone(tzinfo).replace(tzinfo=None).isoformat(),
                 native_temperature=data["temp_max"],
                 condition=MAP_CONDITION[data["icon_descriptor"]],
                 templow=data["temp_min"],
@@ -93,7 +93,7 @@ class WeatherBase(WeatherEntity):
         tzinfo = zoneinfo.ZoneInfo(self.collector.locations_data["data"]["timezone"])
         return [
             Forecast(
-                datetime=iso8601.parse_date(data["time"]).astimezone(tzinfo).isoformat(),
+                datetime=iso8601.parse_date(data["time"]).astimezone(tzinfo).replace(tzinfo=None).isoformat(),
                 native_temperature=data["temp"],
                 condition=MAP_CONDITION[data["icon_descriptor"]],
                 native_precipitation=data["rain_amount_max"],


### PR DESCRIPTION
Removing the timezone offset label ensures that HA uses weather station timezone instead of HA instance timezone. HA already converts the times for us so having both the integration and HA converting the times was causing them to be pushed back 1-2 hours. 

Each weather entity will now show the local time of that station instead of the HA's local time.

Old `datetime` value:
```
2025-05-11 00:00:00+10:00
```
New `datetime` value:
```
2025-05-11 00:00:00
```